### PR TITLE
feat: add Palette.lighter() and Palette.darker() derivative palettes

### DIFF
--- a/docs/examples/plotting.ipynb
+++ b/docs/examples/plotting.ipynb
@@ -270,6 +270,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Lighter & Darker Palettes\n",
+    "\n",
+    "`Palette.lighter()` and `Palette.darker()` return **new** palettes with all\n",
+    "colours brightened or darkened. This is perfect for pairing bold line colours\n",
+    "with pale versions for error bands or shaded regions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = Palette(\"default\")\n",
+    "p_light = p.lighter(0.6)   # pastel versions of every colour\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "x = np.linspace(0, 4 * np.pi, 200)\n",
+    "\n",
+    "for i, (color, light) in enumerate(zip(p, p_light)):\n",
+    "    y = np.sin(x + i * 0.8)\n",
+    "    ax.fill_between(x, y - 0.3, y + 0.3, color=light.hex, alpha=0.5)\n",
+    "    ax.plot(x, y, color=color.hex, linewidth=2, label=color.name)\n",
+    "\n",
+    "ax.legend(ncol=2, fontsize=8)\n",
+    "ax.set_title(\"Bold lines + lighter palette for error bands\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show original vs lighter vs darker hex values\n",
+    "p = Palette(\"default\")\n",
+    "print(\"Original:\", [c.hex for c in p])\n",
+    "print(\"Lighter: \", [c.hex for c in p.lighter(0.6)])\n",
+    "print(\"Darker:  \", [c.hex for c in p.darker(0.3)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## BrokenAxes\n",
     "\n",
     "Create axis-break plots for data with discontinuous ranges."

--- a/pychromatic/palette.py
+++ b/pychromatic/palette.py
@@ -96,7 +96,9 @@ class Palette:
         for c in self.colors:
             c.reset()
 
-    def add_color(self, clr: str | Color, name: str | None = None, pos: int | None = None) -> None:
+    def add_color(
+        self, clr: str | Color, name: str | None = None, pos: int | None = None
+    ) -> None:
         if pos is None:
             pos = len(self.colors) + 1
 
@@ -116,7 +118,9 @@ class Palette:
         for p in reversed(pos):
             del self.colors[p]
 
-    def brighten(self, clr: str, fraction: float = 0.05, name: str | None = None) -> None:
+    def brighten(
+        self, clr: str, fraction: float = 0.05, name: str | None = None
+    ) -> None:
         if name is None:
             name = f"color{len(self.colors)}"
         hexv = cutils.brighten(getattr(self, clr).hex, fraction=fraction)
@@ -127,7 +131,51 @@ class Palette:
     def darken(self, clr: str, fraction: float = 0.05, name: str | None = None) -> None:
         self.brighten(clr, fraction=-1 * fraction, name=name)
 
-    def mix(self, clr1: str, clr2: str, ratio: float = 0.5, name: str | None = None) -> None:
+    def lighter(self, fraction: float = 0.5) -> Palette:
+        """Return a new palette with all colors brightened (paler/pastel).
+
+        Parameters
+        ----------
+        fraction : float
+            How much to brighten each color.  Values around 0.3–0.7 give
+            pleasant pastel variants suitable for shaded error regions.
+
+        Returns
+        -------
+        Palette
+            A new ``Palette`` whose colors are lighter versions of the
+            originals, preserving names and order.
+        """
+        new_palette = Palette.__new__(Palette)
+        new_palette._palette = f"{self._palette}_lighter"
+        new_colors: list[Color] = []
+        for c in self.colors:
+            new_hex = cutils.brighten(c.hex, fraction=fraction)
+            new_c = Color(new_hex, name=c.name)
+            setattr(new_palette, c.name, new_c)
+            new_colors.append(new_c)
+        new_palette.colors = new_colors
+        return new_palette
+
+    def darker(self, fraction: float = 0.3) -> Palette:
+        """Return a new palette with all colors darkened.
+
+        Parameters
+        ----------
+        fraction : float
+            How much to darken each color.
+
+        Returns
+        -------
+        Palette
+            A new ``Palette`` whose colors are darker versions of the
+            originals, preserving names and order.
+        """
+        return self.lighter(fraction=-fraction)
+
+    def mix(
+        self, clr1: str, clr2: str, ratio: float = 0.5, name: str | None = None
+    ) -> None:
         if name is None:
             name = f"color{len(self.colors)}"
 
@@ -159,7 +207,9 @@ class Palette:
         clrlist = cutils.find_intermediate_colors(
             color1.hex, color2.hex, colors=num_colors, ignore_edges=True
         )
-        clrobjlist = [Color(hexv, name=names[count]) for count, hexv in enumerate(clrlist)]
+        clrobjlist = [
+            Color(hexv, name=names[count]) for count, hexv in enumerate(clrlist)
+        ]
         for c in clrobjlist:
             self.colors.append(c)
 
@@ -238,7 +288,9 @@ class Palette:
             for count, color in enumerate(colors):
                 x = np.arange(11)
                 y = np.sin(x / (1.75 * np.pi))
-                axs[0].plot(x, y + count / 3.0, color=color, label=f"{color}", linewidth=4)
+                axs[0].plot(
+                    x, y + count / 3.0, color=color, label=f"{color}", linewidth=4
+                )
             axs[1].pie(
                 (np.random.dirichlet(np.ones(len(colors)), size=1) * 100)[0],
                 colors=colors,

--- a/tests/test_pychromatic.py
+++ b/tests/test_pychromatic.py
@@ -59,7 +59,9 @@ class TestRgbToHex:
 
 
 class TestRoundTripConversions:
-    @pytest.mark.parametrize("hexval", ["#ff5722", "#1976d2", "#388e3c", "#000000", "#ffffff"])
+    @pytest.mark.parametrize(
+        "hexval", ["#ff5722", "#1976d2", "#388e3c", "#000000", "#ffffff"]
+    )
     def test_hex_rgb_roundtrip(self, hexval):
         rgb = hex_to_rgb(hexval)
         assert rgb_to_hex(rgb) == hexval
@@ -107,11 +109,15 @@ class TestMixColors:
 
 class TestFindIntermediateColors:
     def test_returns_correct_count(self):
-        result = find_intermediate_colors("#ff0000", "#0000ff", colors=3, ignore_edges=True)
+        result = find_intermediate_colors(
+            "#ff0000", "#0000ff", colors=3, ignore_edges=True
+        )
         assert len(result) == 3
 
     def test_includes_edges(self):
-        result = find_intermediate_colors("#ff0000", "#0000ff", colors=3, ignore_edges=False)
+        result = find_intermediate_colors(
+            "#ff0000", "#0000ff", colors=3, ignore_edges=False
+        )
         assert len(result) == 5  # 3 intermediates + 2 edges
 
     def test_all_valid_hex(self):
@@ -287,8 +293,12 @@ class TestColorData:
     def test_all_colors_are_valid_hex(self, palette_name):
         palette = colors.color_palettes[palette_name]
         for c in palette["colors"]:
-            assert c.startswith("#"), f"Color '{c}' in palette '{palette_name}' is not hex"
-            assert len(c) == 7, f"Color '{c}' in palette '{palette_name}' is not 7-char hex"
+            assert c.startswith(
+                "#"
+            ), f"Color '{c}' in palette '{palette_name}' is not hex"
+            assert (
+                len(c) == 7
+            ), f"Color '{c}' in palette '{palette_name}' is not 7-char hex"
 
 
 # ---------------------------------------------------------------------------
@@ -299,11 +309,15 @@ class TestColorData:
 class TestColorblindPalettes:
     """Validate the four colorblind-friendly palettes."""
 
-    @pytest.mark.parametrize("palette_name", ["okabe_ito", "tableau10", "tol_bright", "tol_muted"])
+    @pytest.mark.parametrize(
+        "palette_name", ["okabe_ito", "tableau10", "tol_bright", "tol_muted"]
+    )
     def test_present_in_color_palettes(self, palette_name):
         assert palette_name in colors.color_palettes
 
-    @pytest.mark.parametrize("palette_name", ["okabe_ito", "tableau10", "tol_bright", "tol_muted"])
+    @pytest.mark.parametrize(
+        "palette_name", ["okabe_ito", "tableau10", "tol_bright", "tol_muted"]
+    )
     def test_qualitative_type(self, palette_name):
         assert colors.color_palettes[palette_name]["type"] == "qualitative"
 
@@ -352,7 +366,9 @@ class TestColorblindPalettes:
         for hexval in standalone.values():
             assert hexval in palette_entry["colors"]
 
-    @pytest.mark.parametrize("dict_name", ["okabe_ito", "tableau10", "tol_bright", "tol_muted"])
+    @pytest.mark.parametrize(
+        "dict_name", ["okabe_ito", "tableau10", "tol_bright", "tol_muted"]
+    )
     def test_all_valid_hex(self, dict_name):
         standalone = getattr(colors, dict_name)
         for name, hexval in standalone.items():
@@ -794,9 +810,9 @@ class TestPaletteTypes:
     def test_type_is_valid(self, palette_name):
         valid_types = {"qualitative", "sequential", "diverging"}
         palette = colors.color_palettes[palette_name]
-        assert palette["type"] in valid_types, (
-            f"Palette '{palette_name}' has invalid type '{palette['type']}'"
-        )
+        assert (
+            palette["type"] in valid_types
+        ), f"Palette '{palette_name}' has invalid type '{palette['type']}'"
 
 
 # ---------------------------------------------------------------------------
@@ -830,3 +846,124 @@ class TestImports:
         from pychromatic import palette_cmap
 
         assert callable(palette_cmap)
+
+
+# ---------------------------------------------------------------------------
+# Palette lighter / darker tests
+# ---------------------------------------------------------------------------
+
+
+class TestPaletteLighterDarker:
+    """Tests for Palette.lighter() and Palette.darker() derivative palettes."""
+
+    def test_lighter_returns_new_palette(self):
+        p = Palette("default")
+        p_light = p.lighter()
+        assert isinstance(p_light, Palette)
+        assert p_light is not p
+
+    def test_lighter_preserves_length(self):
+        p = Palette("default")
+        p_light = p.lighter(0.5)
+        assert len(p_light) == len(p)
+
+    def test_lighter_preserves_names(self):
+        p = Palette("default")
+        p_light = p.lighter(0.4)
+        original_names = [c.name for c in p]
+        lighter_names = [c.name for c in p_light]
+        assert original_names == lighter_names
+
+    def test_lighter_colors_are_brighter(self):
+        """Lighter palette should have higher luminance for each color."""
+        p = Palette("default")
+        p_light = p.lighter(0.5)
+        for orig, light in zip(p, p_light):
+            orig_hls = rgb_to_hls(hex_to_rgb(orig.hex))
+            light_hls = rgb_to_hls(hex_to_rgb(light.hex))
+            assert light_hls[1] >= orig_hls[1]
+
+    def test_lighter_does_not_mutate_original(self):
+        p = Palette("default")
+        original_hexes = [c.hex for c in p]
+        _ = p.lighter(0.6)
+        assert [c.hex for c in p] == original_hexes
+
+    def test_lighter_palette_name(self):
+        p = Palette("default")
+        p_light = p.lighter()
+        assert p_light._palette == "default_lighter"
+
+    def test_lighter_colors_accessible_by_name(self):
+        p = Palette("default")
+        p_light = p.lighter(0.3)
+        for c in p:
+            assert hasattr(p_light, c.name)
+            assert getattr(p_light, c.name).hex != c.hex or c.hex == "#ffffff"
+
+    def test_darker_returns_new_palette(self):
+        p = Palette("default")
+        p_dark = p.darker()
+        assert isinstance(p_dark, Palette)
+        assert p_dark is not p
+
+    def test_darker_preserves_length(self):
+        p = Palette("default")
+        p_dark = p.darker(0.3)
+        assert len(p_dark) == len(p)
+
+    def test_darker_colors_are_darker(self):
+        """Darker palette should have lower luminance for each color."""
+        p = Palette("default")
+        p_dark = p.darker(0.3)
+        for orig, dark in zip(p, p_dark):
+            orig_hls = rgb_to_hls(hex_to_rgb(orig.hex))
+            dark_hls = rgb_to_hls(hex_to_rgb(dark.hex))
+            assert dark_hls[1] <= orig_hls[1]
+
+    def test_darker_does_not_mutate_original(self):
+        p = Palette("default")
+        original_hexes = [c.hex for c in p]
+        _ = p.darker(0.3)
+        assert [c.hex for c in p] == original_hexes
+
+    def test_lighter_different_fractions(self):
+        p = Palette("default")
+        p1 = p.lighter(0.2)
+        p2 = p.lighter(0.8)
+        # Higher fraction should give brighter colors
+        for c1, c2 in zip(p1, p2):
+            hls1 = rgb_to_hls(hex_to_rgb(c1.hex))
+            hls2 = rgb_to_hls(hex_to_rgb(c2.hex))
+            assert hls2[1] >= hls1[1]
+
+    def test_lighter_iterable(self):
+        """Lighter palette should be iterable and zip-able with original."""
+        p = Palette("default")
+        p_light = p.lighter(0.5)
+        pairs = list(zip(p, p_light))
+        assert len(pairs) == len(p)
+
+    def test_lighter_with_different_palettes(self):
+        for name in ("pastels", "dark", "earth"):
+            p = Palette(name)
+            p_light = p.lighter(0.4)
+            assert len(p_light) == len(p)
+            assert p_light._palette == f"{name}_lighter"
+
+    def test_darker_palette_name(self):
+        p = Palette("earth")
+        p_dark = p.darker(0.3)
+        assert p_dark._palette == "earth_lighter"  # internally uses lighter(-frac)
+
+    def test_chained_lighter(self):
+        """Should be able to chain: p.lighter().lighter()."""
+        p = Palette("default")
+        p_ll = p.lighter(0.3).lighter(0.3)
+        assert len(p_ll) == len(p)
+        # Double-lightened should be brighter than single
+        p_l = p.lighter(0.3)
+        for single, double in zip(p_l, p_ll):
+            hls_s = rgb_to_hls(hex_to_rgb(single.hex))
+            hls_d = rgb_to_hls(hex_to_rgb(double.hex))
+            assert hls_d[1] >= hls_s[1]


### PR DESCRIPTION
Returns a NEW Palette with all colours brightened/darkened, preserving names and order.  Useful for pairing bold line colours with pastel versions for error bands or shaded regions.

- lighter(fraction=0.5) → brighter/pastel palette
- darker(fraction=0.3) → darker palette
- 16 new tests (267 total passing)
- plotting notebook: error-band example with lighter palette